### PR TITLE
Feature/tag autocomplete

### DIFF
--- a/PlantTrackerApp.Client/Pages/Index.razor
+++ b/PlantTrackerApp.Client/Pages/Index.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 @using System.ComponentModel.DataAnnotations
 @inject HttpClient Http
+@inject IJSRuntime JS
 
 <style>
     body {
@@ -139,6 +140,57 @@
             box-shadow: 0 1px 2px rgba(0,0,0,0.05);
     }
 
+    .tag-suggestions {
+        list-style: none;
+        padding-left: 0;
+        margin-top: 4px;
+        background: #ffffff;
+        border: 1px solid #c8e6c9;
+        border-radius: 6px;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+        max-height: 150px;
+        overflow-y: auto;
+        z-index: 1000;
+        position: absolute;
+        width: fit-content;
+    }
+
+    .tag-suggestions li {
+        padding: 8px 12px;
+        cursor: pointer;
+        font-size: 0.95rem;
+        transition: background 0.2s ease;
+    }
+
+    .tag-suggestions li:hover {
+        background-color: #e0f2f1;
+    }
+
+    .tag-chip {
+        display: inline-flex;
+        align-items: center;
+        background-color: #b2fab4;
+        color: #2e7d32;
+        padding: 3px 8px;
+        margin: 2px;
+        border-radius: 12px;
+        font-size: 0.85em;
+    }
+
+    .tag-close {
+        background: none;
+        border: none;
+        color: #2e7d32;
+        font-weight: bold;
+        margin-left: 6px;
+        cursor: pointer;
+        font-size: 1em;
+    }
+
+        .tag-close:hover {
+            color: #d32f2f;
+        }
+
     @@media (max-width: 768px) {
         .table {
             /* display: block; */
@@ -264,9 +316,32 @@ else
                     <ValidationMessage For="@(() => editPlant.LastWatered)" class="validation-message" />
                 </div>
 
-                <div class="form-group" style="flex: 1 1 100%;">
+                <div id="tag-input-container" class="form-group" style="flex: 1 1 100%; position: relative;">
                     <label>Tags (comma-separated):</label>
-                    <InputText @bind-Value="editPlant.Tags" />
+                    <InputText @bind-Value="editPlant.Tags"
+                               oninput="@((ChangeEventArgs e) => OnTagsChanged(e.Value?.ToString() ?? ""))" />
+
+                    <div class="tags">
+                        @foreach (var tag in editPlant.TagList)
+                        {
+                            <span class="tag-chip">
+                                @tag
+                                <button type="button" @onclick="() => RemoveTag(tag)" class="tag-close">×</button>
+                            </span>
+                        }
+                    </div>
+
+                    @if (tagSuggestions.Any())
+                    {
+                        <ul class="tag-suggestions">
+                            @foreach (var suggestion in tagSuggestions)
+                            {
+                                <li @onclick="@(() => AddTagSuggestion(suggestion))">
+                                    @suggestion
+                                </li>
+                            }
+                        </ul>
+                    }
                 </div>
             </div>
 
@@ -284,6 +359,9 @@ else
     private string searchTerm = "";
     private string selectedTag = "";
     private bool formIsValid = false;
+    private List<string> tagSuggestions = new();
+    private DotNetObjectReference<Index>? _dotNetRef;
+    private ElementReference tagInputContainer;
 
     protected override async Task OnInitializedAsync()
     {
@@ -314,9 +392,13 @@ else
             LastWatered = plant.LastWatered,
             Tags = plant.Tags
         };
+
         editContext = new EditContext(editPlant);
         editContext.OnFieldChanged += (_, __) => formIsValid = editContext.Validate();
-        formIsValid = false;
+
+        // 🔥 Trigger validation immediately for pre-filled fields
+        formIsValid = editContext.Validate();
+
         showForm = true;
     }
 
@@ -378,5 +460,55 @@ else
             string.IsNullOrWhiteSpace(Tags)
                 ? Enumerable.Empty<string>()
                 : Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private void OnTagsChanged(string input)
+    {
+        editPlant.Tags = input;
+
+        // Get last token after comma
+        var partial = input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).LastOrDefault() ?? "";
+
+        tagSuggestions = AllTags
+            .Where(tag => tag.StartsWith(partial, StringComparison.OrdinalIgnoreCase) &&
+                          !editPlant.TagList.Contains(tag))
+            .Take(5)
+            .ToList();
+    }
+
+    private void AddTagSuggestion(string suggestion)
+    {
+        var current = editPlant.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+
+        if (current.Count > 0)
+            current[current.Count - 1] = suggestion;
+        else
+            current.Add(suggestion);
+
+        editPlant.Tags = string.Join(", ", current);
+        tagSuggestions.Clear();
+    }
+
+    [JSInvokable]
+    public void ClearTagSuggestions()
+    {
+        tagSuggestions.Clear();
+        StateHasChanged();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("registerOutsideClick", _dotNetRef, "tag-input-container");
+        }
+    }
+
+    private void RemoveTag(string tagToRemove)
+    {
+        Console.WriteLine($"RemoveTag called with: {tagToRemove}");
+        var tags = editPlant.TagList.Where(tag => !string.Equals(tag, tagToRemove, StringComparison.OrdinalIgnoreCase)).ToList();
+        editPlant.Tags = string.Join(", ", tags);
     }
 }

--- a/PlantTrackerApp.Client/Pages/Index.razor
+++ b/PlantTrackerApp.Client/Pages/Index.razor
@@ -130,14 +130,14 @@
 
     .search-filter-row input[type="text"],
     .search-filter-row select {
-            flex: 1;
-            min-width: 200px;
-            padding: 8px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-            font-size: 1rem;
-            background-color: #ffffff;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+        flex: 1;
+        min-width: 200px;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        font-size: 1rem;
+        background-color: #ffffff;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.05);
     }
 
     .tag-suggestions {
@@ -186,10 +186,10 @@
         cursor: pointer;
         font-size: 1em;
     }
-
-        .tag-close:hover {
-            color: #d32f2f;
-        }
+    
+    .tag-close:hover {
+        color: #d32f2f;
+    }
 
     @@media (max-width: 768px) {
         .table {
@@ -396,7 +396,7 @@ else
         editContext = new EditContext(editPlant);
         editContext.OnFieldChanged += (_, __) => formIsValid = editContext.Validate();
 
-        // 🔥 Trigger validation immediately for pre-filled fields
+        // Trigger validation immediately for pre-filled fields
         formIsValid = editContext.Validate();
 
         showForm = true;
@@ -507,7 +507,6 @@ else
 
     private void RemoveTag(string tagToRemove)
     {
-        Console.WriteLine($"RemoveTag called with: {tagToRemove}");
         var tags = editPlant.TagList.Where(tag => !string.Equals(tag, tagToRemove, StringComparison.OrdinalIgnoreCase)).ToList();
         editPlant.Tags = string.Join(", ", tags);
     }

--- a/PlantTrackerApp.Client/wwwroot/index.html
+++ b/PlantTrackerApp.Client/wwwroot/index.html
@@ -27,6 +27,20 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
+
+    <script>
+        window.registerOutsideClick = function (dotNetObjRef, elementId) {
+            function handler(e) {
+                const el = document.getElementById(elementId);
+                if (el && !el.contains(e.target)) {
+                    dotNetObjRef.invokeMethodAsync('ClearTagSuggestions');
+                }
+            }
+            document.addEventListener('click', handler);
+
+            return () => document.removeEventListener('click', handler);
+        };
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
Adding inline tag autocomplete to the plant form. Users can see suggestions as they type and click to auto-complete tags.

#### Features  
- Shows suggestions from existing tags  
- Click to insert a suggestion  
- Tags display as chips with remove buttons  
- Suggestions hide when clicking outside  
- Form validation now works properly when editing existing plants